### PR TITLE
fix: simplify typedoc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Lint:
 
 Generate HTML API Documentation:
 
-`bunx typedoc --readme none index.ts`
+`bunx typedoc index.ts`
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,11 @@
   },
   "peerDependencies": {
     "typescript": "^6.0.3"
+  },
+  "typedocOptions": {
+    "readme": "none",
+    "exclude": [
+      "tests/**"
+    ]
   }
 }


### PR DESCRIPTION
Move typedoc options to package.json so the CLI command is simply `bunx typedoc index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)