### PR TITLE
feat: add build step for Node.js and TypeScript consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ Install dependencies:
 
 `bun install`
 
-Build (remove generated `.gitignore` to allow npm publish from root of
+Build WASM (remove generated `.gitignore` to allow npm publish from root of
 repository):
 
 `wasm-pack build --target web --release --no-pack && rm pkg/.gitignore`
+
+Build JS/types (produces `dist/` for Node.js and TypeScript consumers; Bun uses raw source directly):
+
+`bun run build`
 
 Test:
 

--- a/package.json
+++ b/package.json
@@ -16,15 +16,28 @@
     "type": "git",
     "url": "git+https://github.com/flowscripter/template-bun-wasm-rust-library.git"
   },
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
+    "dist",
     "src/**/*",
     "pkg/**/*",
     "index.ts",
     "README.md",
     "LICENSE"
   ],
-  "type": "module",
-  "module": "index.ts",
+  "scripts": {
+    "build": "bun build index.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,14 @@
     "type": "git",
     "url": "git+https://github.com/flowscripter/template-bun-wasm-rust-library.git"
   },
+  "files": [
+    "dist",
+    "src/**/*",
+    "pkg/**/*",
+    "index.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -27,19 +35,11 @@
       "default": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "src/**/*",
-    "pkg/**/*",
-    "index.ts",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "build": "bun build index.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
-  },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "bun build index.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `bun run build` script: runs `bun build index.ts --outdir dist --target bun` then `tsc -p tsconfig.build.json`
- Add `tsconfig.build.json` extending the base config with `emitDeclarationOnly`, `declaration`, `declarationMap`, `rewriteRelativeImportExtensions`, and `outDir: dist`
- Update `package.json` with `main`, `types`, `exports` (with `bun` condition for raw source), `files`, and `scripts` fields
- Update README with build step documentation

Bun consumers use raw `.ts` source via the `bun` exports condition. Node.js and TypeScript consumers use `dist/index.js` and `dist/index.d.ts`.

## Test plan

- [ ] `wasm-pack build --target web --release --no-pack && rm pkg/.gitignore && bun install && bun run build` produces `dist/index.js` and `dist/index.d.ts`
- [ ] CI workflow runs `bun run build` before semantic-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)